### PR TITLE
Disable non active maven repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,17 +63,6 @@
   </properties>
   <pluginRepositories>
     <pluginRepository>
-      <id>maven2-repository.dev.java.net</id>
-      <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/2/</url>
-      <layout>default</layout>
-    </pluginRepository>
-    <pluginRepository>
-      <id>maven2-glassfish-repository.dev.java.net</id>
-      <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/glassfish/</url>
-    </pluginRepository>
-    <pluginRepository>
       <id>maven2-repository.atlassian</id>
       <name>Atlassian Maven Repository</name>
       <url>https://maven.atlassian.com/repository/public</url>


### PR DESCRIPTION
There is no maven repo on oracle anymore.
So drop it to speed up build.