### PR TITLE
Fix AMBARI-13951

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/PropertyInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/PropertyInfo.java
@@ -19,9 +19,12 @@
 package org.apache.ambari.server.state;
 
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import org.apache.ambari.server.controller.StackConfigurationResponse;
 import org.w3c.dom.Element;
 
+import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyElement;
@@ -71,6 +74,14 @@ public class PropertyInfo {
   @XmlElementWrapper(name="property_depended_by")
   private Set<PropertyDependencyInfo> dependedByProperties =
     new HashSet<PropertyDependencyInfo>();
+
+  //This method is called after all the properties (except IDREF) are unmarshalled for this object,
+  //but before this object is set to the parent object.
+  void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+    // Iterate through propertyTypes and remove any unrecognized property types
+    // that may be introduced with custom service definitions
+    propertyTypes.remove(null);
+  }
 
   public PropertyInfo() {
 


### PR DESCRIPTION
java.lang.RuntimeException: Unable to serialize to json: org.codehaus.jackson.JsonGenerationException: Null key for a Map not allowed in JSON (use a converting NullKeySerializer?)
       at org.apache.ambari.server.api.services.serializers.JsonSerializer.serialize(JsonSerializer.java:71)
       at org.apache.ambari.server.api.services.BaseService.handleRequest(BaseService.java:115)
       at org.apache.ambari.server.api.services.BaseService.handleRequest(BaseService.java:75)
       at org.apache.ambari.server.api.services.ClusterService.updateCluster(ClusterService.java:151)
       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)