### PR TITLE
Fix and speed.

### DIFF
--- a/ambari-metrics/ambari-metrics-storm-sink/pom.xml
+++ b/ambari-metrics/ambari-metrics-storm-sink/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
   <packaging>jar</packaging>
 
   <properties>
-    <storm.version>1.1.0-SNAPSHOT</storm.version>
+    <storm.version>1.1.0</storm.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -64,17 +64,6 @@
   </properties>
   <pluginRepositories>
     <pluginRepository>
-      <id>maven2-repository.dev.java.net</id>
-      <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/2/</url>
-      <layout>default</layout>
-    </pluginRepository>
-    <pluginRepository>
-      <id>maven2-glassfish-repository.dev.java.net</id>
-      <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/glassfish/</url>
-    </pluginRepository>
-    <pluginRepository>
       <id>maven2-repository.atlassian</id>
       <name>Atlassian Maven Repository</name>
       <url>https://maven.atlassian.com/repository/public</url>


### PR DESCRIPTION
cfb2ff4 (Anton Chevychalov, 2 minutes ago)
   Fix "unable to find storm-core:1.1.0-SNAPSHOT"

   [ERROR] Failed to execute goal on project ambari-metrics-storm-sink: Could
   not resolve dependencies for project
   org.apache.ambari:ambari-metrics-storm-sink:jar:2.5.0.0.2: Could not find
   artifact org.apache.storm:storm-core:jar:1.1.0-SNAPSHOT in apache-hadoop

dd1ffbc (Anton Chevychalov, 5 weeks ago)
   Disable non active maven repos

   There is no maven repo on oracle anymore. So drop it to speed up build.