### PR TITLE
ADH-116 Fix imports in adh 1.0 stack_adviser

### DIFF
--- a/ambari-server/src/main/resources/stacks/ADH/1.0/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/ADH/1.0/services/stack_advisor.py
@@ -20,7 +20,7 @@ limitations under the License.
 import re
 import os
 import sys
-from math import ceil, floor
+import math
 
 from stack_advisor import DefaultStackAdvisor
 
@@ -715,7 +715,7 @@ class ADH10StackAdvisor(DefaultStackAdvisor):
     '''containers = max(3, min (2*cores,min (1.8*DISKS,(Total available RAM) / MIN_CONTAINER_SIZE))))'''
     cluster["containers"] = round(max(3,
                                 min(2 * cluster["cpu"],
-                                    min(ceil(1.8 * cluster["disk"]),
+                                    min(math.ceil(1.8 * cluster["disk"]),
                                             cluster["totalAvailableRam"] / cluster["minContainerSize"]))))
 
     '''ramPerContainers = max(2GB, RAM - reservedRam - hBaseRam) / containers'''


### PR DESCRIPTION
That fix:
Error occured in stack advisor.
Error details: global name 'math' is not defined