### PR TITLE
ADH-383 Remove phantomjs in contrib jobs

### DIFF
--- a/contrib/views/jobs/src/main/resources/ui/package.json
+++ b/contrib/views/jobs/src/main/resources/ui/package.json
@@ -17,7 +17,6 @@
     "grunt-contrib-watch": "~0.5.2",
     "grunt-rev": "~0.1.0",
     "grunt-usemin": "~0.1.12",
-    "grunt-mocha": "~0.4.1",
     "grunt-open": "~0.2.0",
     "grunt-svgmin": "~0.2.0",
     "grunt-concurrent": "~0.3.0",


### PR DESCRIPTION
Remove grunt-mocha from devDependencies to remove phantomjs, because it's not
working on linux/ppc